### PR TITLE
Changed to get the link in bio

### DIFF
--- a/algorithm_story.py
+++ b/algorithm_story.py
@@ -44,11 +44,15 @@ def generate():
         output_link += i + "\n"
 
     output_link = "Read more on: \n"+output_link + \
-        "(or you may dm us to get the link!)"
+        "(or get the link in our bio!)"
     output_title = "Today's algorithm:\n" + output_title
     output_cert('title', output_title, title_len)
     output_cert('link', output_link, link_len)
     output_cert('summary', output_text, text_len)
+
+    link = open("output_link.txt", "w")
+    link.write(output_link)
+    link.close()
 
 
 def get_algorithm():

--- a/output_link.txt
+++ b/output_link.txt
@@ -1,0 +1,3 @@
+Read more on: 
+https://en.wikipedia.org/wiki/Decision_list
+(or get the link in our bio!)

--- a/tech_news_story.py
+++ b/tech_news_story.py
@@ -31,7 +31,7 @@ def generate(index):
     output_link = res['url'].get('shortLink', output_link)
 
     output_link = "Read more on: \n"+output_link + \
-        "\n"+"(or you may dm us to get the link!)"
+        "\n"+"(or get the link in our bio!)"
 
     paragraphs = soup.get_text().split(". ")
     text_len = 0
@@ -45,6 +45,10 @@ def generate(index):
     output_cert('title', output_title, len(title))
     output_cert('link', output_link, len(link))
     output_cert('summary', output_text, text_len)
+
+    link = open("output_link.txt", "w")
+    link.write(output_link)
+    link.close()
 
 
 NewsFeed = feedparser.parse("https://www.techrepublic.com/rssfeeds/articles/")


### PR DESCRIPTION
Changed "you may dm us to get the link" to "get  the link in our bio".
an output_link.txt file is added where the link of that story will written here. The person who post just need to copy the link in this output_link.txt file to get the link, instead of look into the excel sheet.